### PR TITLE
remove extraneous tooltip code

### DIFF
--- a/wow/core.lua
+++ b/wow/core.lua
@@ -10,8 +10,6 @@ local L = addonTable.locales
 local AdiBags = LibStub("AceAddon-3.0"):GetAddon("AdiBags")
 
 local db = addonTable.db;
-local MatchIDs
-local tooltip
 local Result = {}
 
 -- Debug mode switch
@@ -21,19 +19,6 @@ if debugMode then
 	--@debug@
 	--"Version: " .. '@project-version@'
 	--@end-debug@
-end
-
-local function tooltipInit()
-	local tip, leftside = CreateFrame("GameTooltip"), {}
-	for i = 1, 6 do
-		local left, right = tip:CreateFontString(), tip:CreateFontString()
-		left:SetFontObject(GameFontNormal)
-		right:SetFontObject(GameFontNormal)
-		tip:AddFontStrings(left, right)
-		leftside[i] = left
-	end
-	tip.leftside = leftside
-	return tip
 end
 
 -- Check for existing filter
@@ -77,18 +62,6 @@ local function CreateFilter(name, uiName, uiDesc, title, items)
 		if self.items[tonumber(slotData.itemId)] then
 			return title
 		end
-
-		tooltip = tooltip or tooltipInit()
-		tooltip:SetOwner(UIParent, "ANCHOR_NONE")
-		tooltip:ClearLines()
-
-		if slotData.bag == BANK_CONTAINER then
-			tooltip:SetInventoryItem("player", BankButtonIDToInvSlotID(slotData.slot, nil))
-		else
-			tooltip:SetBagItem(slotData.bag, slotData.slot)
-		end
-
-		tooltip:Hide()
 	end
 end
 


### PR DESCRIPTION
MatchID is never used
Tooltip is never used and generates significant lag when opening bags as each non-matched item creates a frame. You can look at https://wowpedia.fandom.com/wiki/Category:API_namespaces/C_Item for a different option than tooltip scanning if you need to expand functionality in the future.

Plus, API is changing for Dragonflight release: https://wowpedia.fandom.com/wiki/Patch_10.0.2/API_changes
